### PR TITLE
Added neovim location selector support in project preferences

### DIFF
--- a/Editor/Config.cs
+++ b/Editor/Config.cs
@@ -9,8 +9,10 @@ namespace NvimUnity
     public class Config
     {
         public string last_project = "";
+#if UNITY_EDITOR_WIN 
 		public string neovimLocation = "C:\\Program Files\\Neovim\\bin\\nvim.exe";
-        public void MergeMissingDefaults(Config defaults) { }
+#endif
+		public void MergeMissingDefaults(Config defaults) { }
     }
 
     public static class ConfigManager

--- a/Editor/Config.cs
+++ b/Editor/Config.cs
@@ -9,6 +9,7 @@ namespace NvimUnity
     public class Config
     {
         public string last_project = "";
+		public string neovimLocation = "C:\\Program Files\\Neovim\\bin\\nvim.exe";
         public void MergeMissingDefaults(Config defaults) { }
     }
 

--- a/Editor/NeovimEditor.cs
+++ b/Editor/NeovimEditor.cs
@@ -71,12 +71,15 @@ namespace NvimUnity
                     }
                     else
                     {
-                        // Original behavior for other OSes
+			
+#if !UNITY_EDITOR_WIN
+			// Original behavior for other OSes
                         ProcessStartInfo psi = Utils.BuildProcessStartInfo(defaultApp, path, line);
 
                         UnityEngine.Debug.Log($"[NvimUnity] Executing in terminal: {psi.FileName} {psi.Arguments}");
                         Process.Start(psi);
-                    }
+#endif
+					}
                     return true;
                 }
                 catch (Exception ex)
@@ -186,7 +189,7 @@ namespace NvimUnity
             return true;
         }
 
-        public void Save()
+        public static void Save()
         {
             if (needSaveConfig)
             {

--- a/Editor/NeovimEditor.cs
+++ b/Editor/NeovimEditor.cs
@@ -61,13 +61,13 @@ namespace NvimUnity
                         var psi = new ProcessStartInfo
                         {
                             FileName = defaultApp,
-                            Arguments = $"{path} {line}",
+                            Arguments = $"{path} {line} {config.neovimLocation}",
                             UseShellExecute = true,
                             CreateNoWindow = false,
                         };
-
+						
                         UnityEngine.Debug.Log($"[NvimUnity] Executing: {psi.FileName} {psi.Arguments}");
-                        Process.Start(defaultApp, $"{path} {line}");
+                        Process.Start(defaultApp, $"{path} {line} {config.neovimLocation}");
                     }
                     else
                     {
@@ -79,7 +79,7 @@ namespace NvimUnity
                         UnityEngine.Debug.Log($"[NvimUnity] Executing in terminal: {psi.FileName} {psi.Arguments}");
                         Process.Start(psi);
 #endif
-					}
+		    }
                     return true;
                 }
                 catch (Exception ex)
@@ -100,7 +100,13 @@ namespace NvimUnity
             {
                 string cmd = $"<CMD>e +{line} {filePath}<CR>";
                 string nvimArgs = $"--server {Socket} --remote-send \"{cmd}\"";
-                string nvimPath = Utils.GetNeovimPath();
+                string nvimPath = 
+				
+#if UNITY_EDITOR_WIN
+				config.neovimLocation;
+#else
+				Utils.GetNeovimPath();
+#endif
 
                 var psi = new ProcessStartInfo
                 {
@@ -134,6 +140,16 @@ namespace NvimUnity
             }
 
             EditorGUILayout.EndHorizontal();
+	    
+            EditorGUILayout.BeginHorizontal();
+
+            GUILayout.Label("Neovim location", EditorStyles.boldLabel, GUILayout.Width(250));
+            config.neovimLocation = GUILayout.TextField(config.neovimLocation);
+			if(GUILayout.Button("Browse", GUILayout.Width(80))){
+				config.neovimLocation = EditorUtility.OpenFilePanel("Select neovim", "", "exe");
+				ConfigManager.SaveConfig(config);
+			}
+			EditorGUILayout.EndHorizontal();
 
             GUILayout.Space(10);
         }

--- a/Editor/NeovimEditor.cs
+++ b/Editor/NeovimEditor.cs
@@ -60,6 +60,8 @@ namespace NvimUnity
                 {
                     if (OS == "Windows")
                     {
+						
+#if UNITY_EDITOR_WIN
                         var psi = new ProcessStartInfo
                         {
                             FileName = defaultApp,
@@ -71,6 +73,7 @@ namespace NvimUnity
                         if(debugging)
                         UnityEngine.Debug.Log($"[NvimUnity] Executing: {psi.FileName} {psi.Arguments}");
                         Process.Start(defaultApp, $"{path} {line} {config.neovimLocation}");
+#endif
                     }
                     else
                     {
@@ -144,6 +147,8 @@ namespace NvimUnity
 
             EditorGUILayout.EndHorizontal();
 	    
+		
+#if UNITY_EDITOR_WIN
             EditorGUILayout.BeginHorizontal();
 
             GUILayout.Label("Neovim location", EditorStyles.boldLabel, GUILayout.Width(250));
@@ -153,7 +158,7 @@ namespace NvimUnity
 				ConfigManager.SaveConfig(config);
 			}
 			EditorGUILayout.EndHorizontal();
-
+#endif
             GUILayout.Space(10);
         }
 

--- a/Editor/Utils.cs
+++ b/Editor/Utils.cs
@@ -140,10 +140,10 @@ namespace NvimUnity
             }
 #endif
         }
+#if !UNITY_EDITOR_WIN
 
         public static ProcessStartInfo BuildProcessStartInfo(string defaultApp, string path, int line)
         {
-#if !UNITY_EDITOR_WIN
             string preferredTerminal = NeovimPreferences.GetPreferredTerminal();
 
             string fileName = "/usr/bin/env";
@@ -183,13 +183,12 @@ namespace NvimUnity
                 UseShellExecute = true,
                 CreateNoWindow = false
             };
-#endif
-            return null;
         }
+#endif
+#if !UNITY_EDITOR_WIN
 
         public static bool IsTerminalAvailable(string terminalName)
         {
-#if !UNITY_EDITOR_WIN
             UnityEngine.Debug.Log($"[NvimUnity] Checking if terminal is available: {terminalName}");
             try
             {
@@ -213,9 +212,9 @@ namespace NvimUnity
             {
                 return false;
             }
-#endif
-            return true;
         }
+#endif
+
     }
 }
 


### PR DESCRIPTION
neovim location is hardcoded which is a problem if neovim is installed in different location. Neovim location in external editor settings solves the issue:
neovimLocation

![image](https://github.com/user-attachments/assets/73c2b67e-9168-4919-954e-7df4f49d7163)

This pr also requries changes for standalone client. Standalone pr: https://github.com/apyra/nvim-unity-standalone/pull/1